### PR TITLE
Refactor how the Coq module is generated

### DIFF
--- a/bin/coqffi.ml
+++ b/bin/coqffi.ml
@@ -8,7 +8,8 @@ let process models features input ochannel =
   read_cmi input
   |> interface_of_cmi_infos ~features
   |> translate Translation.types_table
-  |> pp_interface models features ochannel
+  |> Vernac.of_interface features models
+  |> Format.fprintf ochannel "%a@?" Vernac.pp_vernac
 
 exception TooManyArguments
 exception MissingInputArgument

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -1,10 +1,9 @@
 open Cmi_format
-open Format
 open Entry
 open Repr
 open Config
 
-type interface = {
+type t = {
   interface_namespace : string list;
   interface_name : string;
   interface_types : type_entry list;
@@ -28,22 +27,22 @@ let empty_interface (modname : string) =
   }
 
 let interface_of_cmi_infos ~features (info : cmi_infos) =
-  let add_primitive_entry (m : interface) (pr : primitive_entry) : interface = {
+  let add_primitive_entry (m : t) (pr : primitive_entry) : t = {
     m with
     interface_primitives = m.interface_primitives @ [pr]
   } in
 
-  let add_function_entry (m : interface) (f : function_entry) : interface = {
+  let add_function_entry (m : t) (f : function_entry) : t = {
     m with
     interface_functions = m.interface_functions @ [f]
   } in
 
-  let add_type_entry (m : interface) (t : type_entry) : interface = {
+  let add_type_entry (m : t) (t : type_entry) : t = {
     m with
     interface_types = m.interface_types @ [t]
   } in
 
-  let add_entry (m : interface) = function
+  let add_entry (m : t) = function
     | EPrim pr -> add_primitive_entry m pr
     | EFunc fn -> add_function_entry m fn
     | EType t -> add_type_entry m t in
@@ -55,7 +54,7 @@ let interface_of_cmi_infos ~features (info : cmi_infos) =
     (empty_interface info.cmi_name)
     info.cmi_sign
 
-let qualname m name =
+let qualified_name m name =
   String.concat "." (m.interface_namespace @ [m.interface_name; name])
 
 let translate tbl m =
@@ -100,332 +99,3 @@ let translate tbl m =
     interface_functions = List.map (translate_function tbl') m.interface_functions;
     interface_primitives = List.map (translate_primitive tbl') m.interface_primitives;
   }
-
-let pp_interface_decl (fmt : formatter) (m : interface) =
-  let interface_name = String.uppercase_ascii m.interface_name in
-  let prims = m.interface_primitives in
-
-  let pp_print_primitive fmt prim =
-    fprintf fmt "@[<hov 2>| %s@ : %a@]"
-      (String.capitalize_ascii prim.prim_name)
-      pp_type_repr_arrows (interface_proj interface_name prim.prim_type) in
-
-  fprintf fmt "@[<v>Inductive %s : Type -> Type :=@ %a.@]"
-    interface_name
-    (pp_print_list ~pp_sep:pp_print_space pp_print_primitive) prims
-
-let pp_functions_decl (fmt : formatter) (m : interface) =
-  let pp_function_decl (fmt : formatter) (f : function_entry) =
-    match f.func_model with
-    | Some model -> fprintf fmt "@[<v 2>@[<hov 2>Definition %s@ : %a :=@]@ %s.@]"
-                      f.func_name
-                      pp_type_repr_arrows f.func_type
-                      model
-    | _ -> fprintf fmt "Axiom (%s : %a)."
-             f.func_name
-             pp_type_repr_arrows f.func_type
-  in
-
-  pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ")
-    pp_function_decl fmt m.interface_functions
-
-let pp_types_decl (fmt : formatter) (m : interface) =
-  let mut_types = find_mutually_recursive_types m.interface_types in
-
-  let rec var_proto ret = function
-    | [] -> ret
-    | x :: rst -> TLambda (x, var_proto ret rst) in
-
-  let ret_type t =
-    TParam (t.type_name, List.map (fun x -> TParam (x, [])) t.type_params) in
-
-  let pp_args fmt = function
-    | [] -> ()
-    | params ->
-      fprintf fmt "@ %a"
-        (pp_print_list ~pp_sep:pp_print_newline
-           (fun fmt -> fprintf fmt "(%s : Type)")) params in
-
-  let pp_type_param (fmt : formatter) (params : string list) =
-    match params with
-    | [] -> pp_print_text fmt "Type"
-    | _ -> fprintf fmt "@[<hov 2>@[<hv 2>forall %a,@] Type@]"
-             (pp_print_list ~pp_sep:pp_print_space
-                (fun fmt name -> fprintf fmt "(%s : Type)" name)) params in
-
-  let pp_constructors ret fmt l =
-    pp_print_list ~pp_sep:pp_print_space
-      (fun fmt e ->
-         fprintf fmt "| %s : %a"
-           e.variant_name
-           pp_mono_type_repr_arrows (var_proto ret e.variant_args)) fmt l in
-
-  let pp_type_decl (fmt : formatter) (t : type_entry) =
-    match (t.type_model, t.type_value) with
-    | (Some model, _) ->
-      fprintf fmt "Definition %s : %a := %s."
-        t.type_name
-        pp_type_param t.type_params
-        model
-    | (_, Variant l) ->
-
-      fprintf fmt "@[<v>@[<hv 2>@[<hov 2>Inductive %s%a@]@ : Type :=@]@ %a.@]"
-        t.type_name
-        pp_args t.type_params
-        (pp_constructors (ret_type t)) l
-    | _ ->
-      fprintf fmt "Axiom (%s : %a)."
-        t.type_name
-        pp_type_param t.type_params
-  in
-
-  let pp_mutually_rectypes_decl (fmt : formatter) (mt : mutually_recursive_types_entry) =
-    match mt with
-    [t] -> pp_type_decl fmt t
-    | _ ->
-      fprintf fmt "@[<v>@[<hv 2>@[<hov 2>Inductive %a.@]"
-        (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ @[<hv 2>@[<hov 2>with ")
-           (fun fmt t ->
-              fprintf fmt "%s%a@]@ : Type :=@]@ %a"
-                t.type_name
-                pp_args t.type_params
-                (pp_constructors (ret_type t))
-                (match t.type_value with
-                 | Variant l -> l
-                 | _ -> assert false))) mt
-  in
-
-  pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ")
-    pp_mutually_rectypes_decl fmt mut_types
-
-let pp_interface_primitive_helpers_decl (fmt : formatter) (m : interface) =
-  let interface_name = String.uppercase_ascii m.interface_name in
-
-  pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ")
-    (fun fmt prim ->
-       let prefix = sprintf "Definition inj_%s `{Inject %s m}"
-           prim.prim_name
-           interface_name in
-       fprintf fmt "@[<hv 2>%a :=@ inject (%s %a)@]."
-         (pp_type_repr_prototype prefix) (interface_proj "m" prim.prim_type)
-         (String.capitalize_ascii prim.prim_name)
-         pp_type_repr_arg_list prim.prim_type)
-    fmt m.interface_primitives;
-
-  fprintf fmt "@ @ ";
-
-  fprintf fmt "@[<v 2>Instance Monad%s_Inject `(Inject %s m) : Monad%s m :=@ { %a@ }.@]"
-    m.interface_name
-    interface_name
-    m.interface_name
-    (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ ; ")
-       (fun fmt prim -> fprintf fmt "%s := inj_%s" prim.prim_name prim.prim_name))
-    m.interface_primitives
-
-let pp_types_extract_decl (fmt : formatter) (m : interface) =
-  let print_args_list = pp_print_list (fun fmt x -> fprintf fmt " \"'%s\"" x) in
-
-  let print_args_prod fmt = function
-    | [] -> ()
-    | [x] -> fprintf fmt "'%s " x
-    | args -> fprintf fmt "(%a) "
-                (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_text fmt ", ")
-                   (fun fmt -> fprintf fmt "'%s")) args in
-
-  pp_print_list ~pp_sep:pp_print_space
-    (fun fmt t ->
-       match (t.type_model, t.type_value) with
-       | (None, Variant l) ->
-         fprintf fmt "@[<hov 2>Extract Inductive %s =>@ \"%s\"@ [%a].@]"
-           t.type_name
-           (qualname m t.type_name)
-           (pp_print_list ~pp_sep:pp_print_space
-              (fun fmt v -> fprintf fmt "\"%s\"" (qualname m v.variant_name))) l
-       | _ ->
-         fprintf fmt "@[<hov 2>Extract Constant %s%a@ => \"%a%s\".@]"
-           t.type_name
-           print_args_list t.type_params
-           print_args_prod t.type_params
-           (qualname m t.type_name)) fmt m.interface_types
-
-let pp_functions_extract_decl (fmt : formatter) (m : interface) =
-  pp_print_list ~pp_sep:pp_print_space
-    (fun fmt f ->
-       fprintf fmt "@[<hov 2>Extract Constant %s@ => \"%s\".@]"
-         f.func_name
-         (qualname m f.func_name)) fmt m.interface_functions
-
-let pp_io_extract (fmt : formatter) (m : interface) =
-  pp_print_list ~pp_sep:pp_print_space
-    (fun fmt prim ->
-       let k_name = "k__" (* TODO: freshen *) in
-       fprintf fmt "@[<hov 2>Extract Constant io_%s =>@ \"(fun %a %s -> %s (%s %a))\".@]"
-         prim.prim_name
-         pp_type_repr_arg_list prim.prim_type
-         k_name
-         k_name
-         (qualname m prim.prim_name)
-         pp_type_repr_arg_list prim.prim_type)
-    fmt m.interface_primitives
-
-let pp_interface_freespec_semantics_decl (fmt : formatter) (m : interface) =
-  let interface_name = String.uppercase_ascii m.interface_name in
-  let semantics_name = String.lowercase_ascii m.interface_name in
-  let prims = m.interface_primitives in
-
-  fprintf fmt "@[<v 2>Definition ml_%s_sem : semantics %s :=@ "
-    semantics_name interface_name;
-  fprintf fmt
-    "@[<v 2>bootstrap (fun a e =>@ local @[<v>match e in %s a return a with@ %a@ end@]).@]@]@ @ "
-    interface_name
-    (pp_print_list ~pp_sep:pp_print_space
-    (fun fmt prim ->
-       fprintf fmt "| %s %a => ml_%s %a"
-         (String.capitalize_ascii prim.prim_name)
-         pp_type_repr_arg_list prim.prim_type
-         prim.prim_name
-         pp_type_repr_arg_list prim.prim_type)) prims
-
-let pp_interface_freespec_handlers_decl (fmt : formatter) (m : interface) =
-  let prims = m.interface_primitives in
-
-  pp_print_list ~pp_sep:pp_print_space
-    (fun fmt prim ->
-      fprintf fmt
-        "Axiom (ml_%s : %a).@ @[<hov 2>Extract Constant ml_%s@ => \"%s.%s.%s\".@]"
-        prim.prim_name
-        pp_type_repr_arrows prim.prim_type
-        prim.prim_name
-        (String.concat "." m.interface_namespace)
-        m.interface_name
-        prim.prim_name) fmt prims
-
-let pp_impure_decl conf fmt m =
-  fprintf fmt "(** * Impure Primitives *)@ @ ";
-
-  fprintf fmt "(** ** Monad *)@ @ ";
-
-  fprintf fmt "@[<v 2>Class Monad%s (m : Type -> Type) : Type :=@ { %a@ }.@]@ @ "
-    m.interface_name
-    (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ ; ")
-       (fun fmt prim -> fprintf fmt "%s : %a"
-           prim.prim_name
-           pp_type_repr_arrows (interface_proj "m" prim.prim_type)))
-    m.interface_primitives;
-
-  if Config.is_enabled conf SimpleIO
-  then begin
-    fprintf fmt "(** ** [IO] Instance *)@ @ ";
-
-    fprintf fmt "%a@ @ "
-      (pp_print_list ~pp_sep:pp_print_space
-         (fun fmt prim ->
-            fprintf fmt "Axiom (io_%s : %a)."
-              prim.prim_name
-              pp_type_repr_arrows (interface_proj "IO" prim.prim_type)))
-      m.interface_primitives;
-
-    fprintf fmt "%a@ @ " pp_io_extract m;
-
-    fprintf fmt "@[<v 2>Instance Monad%s_IO : Monad%s IO :=@ { %a@ }.@]@ @ "
-      m.interface_name
-      m.interface_name
-      (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ ; ")
-         (fun fmt prim -> fprintf fmt "%s := io_%s" prim.prim_name prim.prim_name))
-      m.interface_primitives;
-  end;
-
-  if is_enabled conf Interface
-  then begin
-    fprintf fmt "(** ** Interface Definition *)@ @ ";
-
-    fprintf fmt "@[<v>%a@]@ @ "
-      pp_interface_decl m;
-
-    fprintf fmt "@[<v>%a@]@ @ "
-      pp_interface_primitive_helpers_decl m
-  end;
-
-  if Config.is_enabled conf FreeSpec
-  then begin
-    fprintf fmt "(** ** FreeSpec [semantics] *)@ @ ";
-
-    fprintf fmt "%a@ @ " pp_interface_freespec_handlers_decl m;
-    fprintf fmt "%a" pp_interface_freespec_semantics_decl m
-  end
-
-let not_empty = function
-  | [] -> false
-  | _ -> true
-
-let pp_types fmt m =
-  if not_empty m.interface_types then
-    begin
-      fprintf fmt "(** * Types *)@ @ ";
-
-      fprintf fmt "@[<v>%a@]@ @ "
-        pp_types_decl m;
-
-      fprintf fmt "@[<v>%a@]@ @ "
-        pp_types_extract_decl m
-    end
-
-let pp_funcs fmt m =
-  if not_empty m.interface_functions then
-    begin
-      fprintf fmt "(** * Pure Functions *)@ @ ";
-
-      fprintf fmt "@[<v>%a@]@ @ "
-        pp_functions_decl m;
-
-      fprintf fmt "@[<v>%a@]@ @ "
-        pp_functions_extract_decl m
-    end
-
-let pp_impure conf fmt m =
-  if not_empty m.interface_primitives then
-    begin
-      pp_impure_decl conf fmt m;
-    end
-
-let pp_models fmt = function
-  | (_ :: _) as models -> begin
-      pp_print_list ~pp_sep:pp_print_newline
-        (fun fmt -> fprintf fmt "Require %s.")
-        fmt models;
-      fprintf fmt "@ @ "
-    end
-  | [] -> ()
-
-let pp_interface (models : string list) (features : Config.features)
-    (fmt : formatter) (m : interface) =
-  if not (Config.support_impure_values features)
-  && List.length m.interface_primitives != 0
-  then fprintf err_formatter
-      "Warning: The input module provides impure computations, but no impure backend has been selected.";
-
-  pp_open_vbox fmt 0;
-  fprintf fmt "(* This file has been generated by coqffi. *)@ @ ";
-
-  fprintf fmt "Set Implicit Arguments.@ ";
-  fprintf fmt "Unset Strict Implicit.@ ";
-  fprintf fmt "Set Contextual Implicit.@ ";
-  fprintf fmt "Generalizable All Variables.@ @ ";
-
-  fprintf fmt "From CoqFFI Require Export Extraction.@ ";
-  if is_enabled features SimpleIO
-  then fprintf fmt "From SimpleIO Require Import IO_Monad.@ ";
-  if is_enabled features Interface
-  then fprintf fmt "From CoqFFI Require Import Interface.@ ";
-  if is_enabled features FreeSpec
-  then fprintf fmt "From FreeSpec.Core Require Import Core.@ ";
-  pp_models fmt models;
-
-  pp_types fmt m;
-
-  pp_funcs fmt m;
-
-  pp_impure features fmt m;
-
-  fprintf fmt "(* generated file ends here *)@?";
-  pp_close_box fmt ()

--- a/src/interface.mli
+++ b/src/interface.mli
@@ -1,7 +1,7 @@
 open Entry
 open Config
 
-type interface = {
+type t = {
   interface_namespace : string list;
   interface_name : string;
   interface_types : type_entry list;
@@ -9,13 +9,11 @@ type interface = {
   interface_primitives : primitive_entry list;
 }
 
-val empty_interface : string -> interface
+val empty_interface : string -> t
 
 val interface_of_cmi_infos
-  : features:features -> Cmi_format.cmi_infos -> interface
+  : features:features -> Cmi_format.cmi_infos -> t
 
-val translate : Translation.t -> interface -> interface
+val translate : Translation.t -> t -> t
 
-(** * Format *)
-
-val pp_interface : string list -> features -> Format.formatter -> interface -> unit
+val qualified_name : t -> string -> string

--- a/src/lazylist.ml
+++ b/src/lazylist.ml
@@ -1,0 +1,40 @@
+open Format
+
+type 'a t =
+  | LSeg of 'a * 'a list * 'a t Lazy.t
+  | LNil
+
+let push_list = function
+  | [] -> fun l -> l
+  | x :: r ->
+    let rec push_segment = function
+      | LSeg (y, r', lr) -> LSeg (y, r', lazy (push_segment @@ Lazy.force lr))
+      | _ -> LSeg (x, r, lazy LNil)
+    in push_segment
+
+let push x = push_list [x]
+
+let of_list = function
+  | [] -> LNil
+  | x :: rst -> LSeg (x, rst, lazy LNil)
+
+let singleton x = LSeg (x, [], lazy LNil)
+
+let (|+) ll v = push v ll
+let (|++) ll lv = push_list lv ll
+
+let unpack = function
+  | LNil -> None
+  | LSeg (x, [], lr) -> Some ((x, Lazy.force lr))
+  | LSeg (x, y :: rst, lr) -> Some ((x, LSeg (y, rst, lr)))
+
+let pp_print_lazylist ~pp_sep f fmt ll =
+  let prod_iter f g = fun (x, y) -> f x; g y in
+  let rec aux = function
+    | LNil -> ()
+    | LSeg (x, l, rst) -> begin
+        pp_sep fmt ();
+        pp_print_list ~pp_sep f fmt (x :: l);
+        aux (Lazy.force rst)
+      end in
+  Option.iter (prod_iter (f fmt) aux) @@ unpack ll

--- a/src/lazylist.mli
+++ b/src/lazylist.mli
@@ -1,0 +1,15 @@
+type 'a t
+
+val push : 'a -> 'a t -> 'a t
+val push_list : 'a list -> 'a t -> 'a t
+val of_list : 'a list -> 'a t
+val singleton : 'a -> 'a t
+
+val (|+) : 'a t -> 'a -> 'a t
+val (|++) : 'a t -> 'a list -> 'a t
+
+val pp_print_lazylist : pp_sep:(Format.formatter -> unit -> unit)
+  -> (Format.formatter -> 'a -> unit)
+  -> Format.formatter
+  -> 'a t
+  -> unit

--- a/src/pp.ml
+++ b/src/pp.ml
@@ -1,0 +1,31 @@
+open Format
+open Repr
+
+let pp_list ?(pp_prefix=fun _ _ -> ()) ?(pp_suffix=fun _ _ -> ())
+    ~pp_sep pp fmt =
+  function
+  | _ :: _ as l -> begin
+      pp_prefix fmt ();
+      pp_print_list ~pp_sep pp fmt l;
+      pp_suffix fmt ();
+    end
+  | _ -> ()
+
+let pp_if_not_empty pp fmt = function
+  | _ :: _ -> pp fmt ()
+  | _ -> ()
+
+let pp_args_list fmt args_list =
+  let idx = ref 0 in
+  pp_print_list ~pp_sep:pp_print_space
+    (fun fmt arg -> begin
+         let x = !idx in
+         fprintf fmt "(x%d : %a)" x pp_type_repr arg;
+         idx := x + 1
+       end) fmt args_list
+
+let pp_type_args_list fmt type_args_list =
+  pp_print_list ~pp_sep:pp_print_space
+    (fun fmt arg -> fprintf fmt "(%s : Type)" arg)
+    fmt
+    type_args_list

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -1,0 +1,17 @@
+open Format
+
+val pp_if_not_empty : (formatter -> unit -> unit) -> formatter
+  -> 'a list
+  -> unit
+
+val pp_list : ?pp_prefix:(formatter -> unit -> unit)
+  -> ?pp_suffix:(formatter -> unit -> unit)
+  -> pp_sep:(formatter -> unit -> unit)
+  -> (formatter -> 'a -> unit)
+  -> formatter
+  -> 'a list
+  -> unit
+
+val pp_args_list : formatter -> Repr.type_repr list -> unit
+
+val pp_type_args_list : formatter -> string list -> unit

--- a/src/repr.mli
+++ b/src/repr.mli
@@ -46,14 +46,13 @@ val type_repr_of_type_expr : Types.type_expr -> type_repr
 
 (** {2 Heplers Functions} *)
 
-(** Project the codomain of a function into the [impure] monad provided by
-    FreeSpec, {e i.e.}, [impure_proj ix (a -> .. -> r) ≡ a -> .. -> impure ix
-    r] *)
-val impure_proj : string -> type_repr -> type_repr
+(** Create a function type, {e i.e.}, [tlambda [a; b; c] d ≡ a -> b ->
+    c -> d] *)
+val tlambda : mono_type_repr list -> mono_type_repr -> mono_type_repr
 
-(** Project the codomain of a function into a given interface, {e i.e.},
-    [interface_proj I (a -> .. -> r) ≡ a -> .. -> I r] *)
-val interface_proj : string -> type_repr -> type_repr
+(** Project the codomain of a function into a parameterized type, {e
+    i.e.}, [type_lift T [x r] (a -> .. -> r) ≡ a -> .. -> T x y r] *)
+val type_lift : string -> ?args:(mono_type_repr list) -> type_repr -> type_repr
 
 (** [mono_dependencies t] is the list of types which appear in [t] definition.
     For instance, [mono_dependencies (int * bool) ≡ ["int"; "bool"]] *)
@@ -88,19 +87,22 @@ val translate_mono_type_repr : Translation.t -> mono_type_repr -> mono_type_repr
 
 val translate_type_repr : Translation.t -> type_repr -> type_repr
 
+val type_sort_mono : mono_type_repr
+val type_sort : type_repr
+
+type prototype_repr = {
+  prototype_type_args : string list;
+  prototype_args : type_repr list;
+  prototype_ret_type : type_repr
+}
+
+val type_repr_to_prototype_repr : type_repr -> prototype_repr
+
 (** {2 Pretty-printing Coq Terms} *)
 
 (** Output [TLambda] values as [t0 -> .. -> tn] *)
-val pp_mono_type_repr_arrows : Format.formatter -> mono_type_repr -> unit
+val pp_mono_type_repr : Format.formatter -> mono_type_repr -> unit
 
 (** Output [TLambda] values as [forall (a1 : Type) .. (an : Type), t0 -> .. ->
     tn] *)
-val pp_type_repr_arrows : Format.formatter -> type_repr -> unit
-
-(** Output [TLambda] values as [(a0 : Type) .. (an : Type) (x0 : t0) .. (xm :
-    tm) : tn]). The first argument of [pp_type_repr_prototype] is a prefix to
-    append before this prototype ({e e.g.}, "Definition name" ) *)
-val pp_type_repr_prototype : string -> Format.formatter -> type_repr -> unit
-
-(** For a function which takes [n + 1] arguments, output [x0 .. xn]. *)
-val pp_type_repr_arg_list : Format.formatter -> type_repr -> unit
+val pp_type_repr : Format.formatter -> type_repr -> unit

--- a/src/vernac.ml
+++ b/src/vernac.ml
@@ -1,0 +1,543 @@
+open Entry
+open Format
+open Interface
+open Config
+open Repr
+open Lazylist
+open Pp
+
+type from_require_import = {
+  import_from : string;
+  import_module : string;
+}
+
+let pp_from_require_import fmt fri =
+  fprintf fmt "From %s Require Import %s." fri.import_from fri.import_module
+
+type from_require_export = {
+  export_from : string;
+  export_module : string;
+}
+
+let pp_from_require_export fmt fre =
+  fprintf fmt "From %s Require Export %s." fre.export_from fre.export_module
+
+type require =  {
+  require_module : string;
+}
+
+let pp_require fmt req = fprintf fmt "Require %s." req.require_module
+
+type constructor = {
+  constructor_name : string;
+  constructor_prototype : Repr.prototype_repr
+}
+
+let pp_constructor fmt c =
+  fprintf fmt "| @[<hov 2>@[<hov 2>%s%a%a@]@ : %a@]"
+    c.constructor_name
+    (pp_if_not_empty pp_print_space) c.constructor_prototype.prototype_args
+    pp_args_list c.constructor_prototype.prototype_args
+    pp_type_repr c.constructor_prototype.prototype_ret_type
+
+type inductive = {
+  inductive_name : string;
+  inductive_type_args : string list;
+  inductive_type : Repr.type_repr;
+  inductive_constructors : constructor list;
+}
+
+let pp_inductive fmt = function
+  | [] -> ()
+  | lind ->
+    let pp_inductive_aux fmt ind =
+      fprintf fmt "%s%a%a@ : %a :=@]@ %a"
+        ind.inductive_name
+        (pp_if_not_empty pp_print_space) ind.inductive_type_args
+        pp_type_args_list ind.inductive_type_args
+        pp_type_repr ind.inductive_type
+        (pp_print_list ~pp_sep:pp_print_space
+           pp_constructor) ind.inductive_constructors
+    in
+    fprintf fmt "@[<v>@[<hov 2>Inductive %a.@]"
+      (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ @[<hov 2>with ")
+         pp_inductive_aux) lind
+
+type definition = {
+  def_name : string;
+  def_typeclass_args : string list;
+  def_prototype : Repr.prototype_repr;
+  def_body : Format.formatter -> unit -> unit;
+}
+
+let pp_definition fmt def =
+  fprintf fmt "@[<hov 2>@[<hov 2>Definition %s%a%a%a%a%a@] :@ %a :=@ %a.@]"
+    def.def_name
+    (pp_list
+       ~pp_prefix:(fun fmt _ -> pp_print_string fmt " `{")
+       ~pp_suffix:(fun fmt _ -> pp_print_string fmt "}")
+       ~pp_sep:pp_print_space pp_print_string) def.def_typeclass_args
+    (pp_if_not_empty pp_print_space) def.def_prototype.prototype_type_args
+    pp_type_args_list def.def_prototype.prototype_type_args
+    (pp_if_not_empty pp_print_space) def.def_prototype.prototype_args
+    pp_args_list def.def_prototype.prototype_args
+    pp_type_repr def.def_prototype.prototype_ret_type
+    def.def_body ()
+
+type typeclass = {
+  class_name : string;
+  class_typeclass_args : string list;
+  class_args : (string * Repr.type_repr) list;
+  class_type : Repr.type_repr;
+  class_members : (string * Repr.type_repr) list
+}
+
+let pp_typeclass fmt cls =
+  fprintf fmt "@[<hov 2>@[<hov 2>Class %s%a%a%a%a@] :@ %a :=@ @[<v>{ %a@ @]}.@]"
+    cls.class_name
+    (pp_if_not_empty pp_print_space) cls.class_typeclass_args
+    (pp_print_list ~pp_sep:pp_print_space pp_print_string) cls.class_typeclass_args
+    (pp_if_not_empty pp_print_space) cls.class_args
+    (pp_print_list ~pp_sep:pp_print_space
+       (fun fmt (n, t) -> fprintf fmt "(%s : %a)"
+           n
+           pp_type_repr t)) cls.class_args
+    pp_type_repr cls.class_type
+    (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ ; ")
+       (fun fmt (m, t) -> fprintf fmt "%s : %a"
+           m
+           pp_type_repr t)) cls.class_members
+
+type instance = {
+  instance_name : string;
+  instance_type : Repr.type_repr;
+  instance_members : (string * string) list;
+}
+
+let pp_instance fmt inst =
+  fprintf fmt "@[<hov 2>Instance %s@ : %a :=@ @[<v>{ %a@ }.@]@]"
+    inst.instance_name
+    pp_type_repr inst.instance_type
+    (pp_print_list ~pp_sep:(fun fmt _ -> fprintf fmt "@ ; ")
+       (fun fmt (m,v) -> fprintf fmt "%s := %s" m v)) inst.instance_members
+
+type axiom = {
+  axiom_name : string;
+  axiom_type : Repr.type_repr;
+}
+
+let pp_axiom fmt ax =
+  fprintf fmt "@[<hov 2>Axiom %s@ : %a.@]"
+    ax.axiom_name
+    pp_type_repr ax.axiom_type
+
+type extract_constant = {
+  constant_qualid : string;
+  constant_type_vars : string list;
+  constant_target : string;
+}
+
+let pp_extract_constant fmt extr =
+  let print_args_prod fmt = function
+    | [] -> ()
+    | [x] -> fprintf fmt "'%s " x
+    | args -> fprintf fmt "(%a) "
+                (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_text fmt ", ")
+                   (fun fmt -> fprintf fmt "'%s")) args in
+
+  fprintf fmt "@[<hov 2>Extract Constant %s%a@ => \"%a%s\".@]"
+    extr.constant_qualid
+    (pp_list
+       ~pp_prefix:(fun fmt _ -> pp_print_char fmt '"')
+       ~pp_suffix:(fun fmt _ -> pp_print_char fmt '"')
+       ~pp_sep:(fun fmt _ -> pp_print_string fmt " ")
+       (fun fmt -> fprintf fmt "'%s")) extr.constant_type_vars
+    print_args_prod extr.constant_type_vars
+    extr.constant_target
+
+type extract_inductive = {
+  inductive_qualid : string;
+  inductive_target : string;
+  inductive_variants_target : string list;
+}
+
+let pp_extract_inductive fmt ind =
+  fprintf fmt "@[<hov 2>Extract Inductive %s =>@ \"%s\"@ [@[<hov 2>%a@]].@]"
+    ind.inductive_qualid
+    ind.inductive_target
+    (pp_list ~pp_sep:pp_print_space
+       ~pp_prefix:pp_print_space
+       ~pp_suffix:pp_print_space
+       (fun fmt t -> fprintf fmt "\"%s\"" t)) ind.inductive_variants_target
+
+type t =
+  | Section of string
+  | Subsection of string
+  | Comment of string
+  | Block of t Lazylist.t
+  | CompactedBlock of t Lazylist.t
+  | ConfigPrologue
+  | FromRequireImport of from_require_import
+  | FromRequireExport of from_require_export
+  | Require of require
+  | Definition of definition
+  | Inductive of inductive list
+  | Typeclass of typeclass
+  | Instance of instance
+  | Axiom of axiom
+  | ExtractConstant of extract_constant
+  | ExtractInductive of extract_inductive
+
+let rec pp_vernac fmt = function
+  | Block l ->
+    fprintf fmt "@[<v>%a@]"
+      (pp_print_lazylist ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ") pp_vernac) l
+
+  | CompactedBlock l ->
+    fprintf fmt "@[<v>%a@]"
+      (pp_print_lazylist ~pp_sep:pp_print_space pp_vernac) l
+
+  | Comment str -> fprintf fmt "(* %s *)" str
+
+  | Section str -> fprintf fmt "(** * %s *)" str
+
+  | Subsection str -> fprintf fmt "(** ** %s *)" str
+
+  | ConfigPrologue ->
+      pp_print_list ~pp_sep:pp_print_space pp_print_string fmt [
+        "Set Implicit Arguments.";
+        "Unset Strict Implicit.";
+        "Set Contextual Implicit.";
+        "Generalizable All Variables."
+      ]
+
+  | FromRequireImport fri -> pp_from_require_import fmt fri
+  | FromRequireExport fre -> pp_from_require_export fmt fre
+  | Require req -> pp_require fmt req
+  | Definition def -> pp_definition fmt def
+  | Inductive ind -> pp_inductive fmt ind
+  | Typeclass cls -> pp_typeclass fmt cls
+  | Instance inst -> pp_instance fmt inst
+  | Axiom ax -> pp_axiom fmt ax
+  | ExtractConstant extr -> pp_extract_constant  fmt extr
+  | ExtractInductive ind -> pp_extract_inductive fmt ind
+
+let block_of_list l = Block (of_list l)
+let compacted_block_of_list l = CompactedBlock (of_list l)
+
+let empty = function
+  | [] -> true
+  | _ -> false
+
+let (@?) cond f = if cond then f else (fun x -> x)
+
+let requires_vernac features models =
+  let requires_freespec = Lazylist.push (FromRequireImport {
+      import_from = "FreeSpec.Core";
+      import_module = "Core"
+    }) in
+
+  let requires_io = Lazylist.push (FromRequireImport {
+      import_from = "SimpleIO";
+      import_module = "IO_Monad"
+    }) in
+
+  let requires_interface = Lazylist.push (FromRequireImport {
+      import_from = "CoqFFI";
+      import_module = "Interface"
+    }) in
+
+  Lazylist.push @@ CompactedBlock
+    (singleton (FromRequireExport {
+         export_from = "CoqFFI";
+         export_module = "Extraction"
+       })
+     |> is_enabled features SimpleIO @? requires_io
+     |> is_enabled features Interface @? requires_interface
+     |> is_enabled features FreeSpec @? requires_freespec
+     |++ List.map (fun x -> Require { require_module = x }) models)
+
+let functions_vernac m =
+  let to_def f = match f.func_model with
+    | Some model -> Definition {
+        def_name = f.func_name;
+        def_typeclass_args = [];
+        def_prototype = {
+          prototype_type_args = [];
+          prototype_args = [];
+          prototype_ret_type = f.func_type;
+        };
+        def_body = (fun fmt _ -> pp_print_string fmt model)
+      }
+    | _ -> Axiom { axiom_name = f.func_name; axiom_type = f.func_type }
+  in
+
+  let to_extr f = ExtractConstant {
+      constant_qualid = f.func_name;
+      constant_type_vars = [];
+      constant_target = Interface.qualified_name m f.func_name
+    } in
+
+  Lazylist.push_list [
+    Section "Pure functions";
+    block_of_list @@ List.map to_def m.interface_functions;
+    block_of_list @@ List.map to_extr m.interface_functions;
+  ]
+
+let types_vernac features m vernacs =
+  let mut_types = find_mutually_recursive_types m.interface_types in
+  let transparent = is_enabled features TransparentTypes in
+  let to_type args mono = match args with
+    | [] -> TMono mono
+    | params -> TPoly (params, mono) in
+
+  let to_constructor t v = {
+    constructor_name = v.variant_name;
+    constructor_prototype = {
+      prototype_type_args = [];
+      prototype_args = List.map (fun x -> TMono x) v.variant_args;
+      prototype_ret_type = to_type
+          []
+          (TParam
+             (t.type_name,
+              List.map (fun x -> TParam (x, [])) t.type_params));
+    }
+  } in
+
+  let type_entry_to_vernac t =
+    match (t.type_value, t.type_model, transparent) with
+    | (Variant l, None, true) -> Inductive [{
+        inductive_name = t.type_name;
+        inductive_type_args = t.type_params;
+        inductive_constructors = List.map (to_constructor t) l;
+        inductive_type = to_type [] type_sort_mono;
+      }]
+    | (_, Some m, _) -> Definition {
+        def_name = t.type_name;
+        def_typeclass_args = [];
+        def_prototype = {
+          prototype_type_args = [];
+          prototype_args = [];
+          prototype_ret_type = to_type t.type_params type_sort_mono;
+        };
+        def_body = fun fmt _ -> pp_print_string fmt m;
+      }
+    | _ -> Axiom {
+        axiom_name = t.type_name;
+        axiom_type = to_type t.type_params type_sort_mono
+      } in
+
+  let type_entry_to_inductive t =
+    match (t.type_value, t.type_model, transparent) with
+    | (Variant l, None, true) -> {
+        inductive_name = t.type_name;
+        inductive_type_args = t.type_params;
+        inductive_constructors = List.map (to_constructor t) l;
+        inductive_type = to_type [] type_sort_mono;
+      }
+    | _ -> assert false in
+
+  let mut_type_entries_to_ind t = [
+    Inductive (List.map type_entry_to_inductive t)
+  ] in
+
+  let type_entries_to_vernac = function
+    | (t :: _) as mut_types ->
+      (match (t.type_value, t.type_model, transparent) with
+       | (Variant _, None, true) -> mut_type_entries_to_ind mut_types
+       | _ -> List.map type_entry_to_vernac mut_types)
+    | [] -> [] in
+
+  let to_extract t = match (t.type_value, t.type_model, transparent) with
+    | (Variant l, None, true) ->
+      ExtractInductive {
+        inductive_qualid = t.type_name;
+        inductive_target = Interface.qualified_name m t.type_name;
+        inductive_variants_target =
+          List.map (fun x -> x.variant_name) l
+      }
+    | _ ->
+      ExtractConstant {
+        constant_qualid = t.type_name;
+        constant_type_vars = t.type_params;
+        constant_target = Interface.qualified_name m t.type_name
+      }
+  in
+
+  vernacs
+  |+ Section "Types"
+  |++ List.concat_map type_entries_to_vernac mut_types
+  |+ block_of_list @@ List.map to_extract m.interface_types
+
+let call_vars proto =
+  List.mapi (fun i _ -> sprintf "x%d" i) proto.prototype_args
+
+let io_primitives_vernac m =
+  (* TODO: tailrec? *)
+  let to_axiom prim = Axiom {
+      axiom_name = sprintf "io_%s" prim.prim_name;
+      axiom_type = type_lift "IO" prim.prim_type;
+    } in
+
+  let to_extract_constant prim =
+    let proto = type_repr_to_prototype_repr prim.prim_type in
+    let args = call_vars proto in
+    ExtractConstant {
+      constant_qualid = sprintf "io_%s" prim.prim_name;
+      constant_type_vars = [];
+      constant_target =
+        asprintf "@[<h>(fun%a%a%ak__ -> k__ %a%s%a%a%a)@]"
+          (pp_if_not_empty pp_print_space) args
+          (pp_print_list ~pp_sep:pp_print_space
+             pp_print_string) args
+          (pp_if_not_empty pp_print_space) args
+          (pp_if_not_empty (fun fmt _ -> pp_print_string fmt "(")) args
+          (Interface.qualified_name m prim.prim_name)
+          (pp_if_not_empty pp_print_space) args
+          (pp_print_list ~pp_sep:pp_print_space
+             pp_print_string) args
+          (pp_if_not_empty (fun fmt _ -> pp_print_string fmt ")")) args
+    } in
+
+  let instance_vernac = Instance {
+      instance_name = sprintf "IO_Monad%s" m.interface_name;
+      instance_type =
+        TMono (TParam (sprintf "Monad%s" m.interface_name, [TParam ("IO", [])]));
+      instance_members =
+        List.map (fun prim -> (prim.prim_name, sprintf "io_%s" prim.prim_name))
+          m.interface_primitives
+    } in
+
+  Lazylist.push_list [
+    Subsection "[IO] instance";
+    compacted_block_of_list @@ List.map to_axiom m.interface_primitives;
+    compacted_block_of_list @@ List.map to_extract_constant m.interface_primitives;
+    instance_vernac;
+  ]
+
+let interface_vernac m vernacs =
+  let prim_to_constructor prim = {
+    constructor_name =
+      String.capitalize_ascii prim.prim_name;
+    constructor_prototype = {
+      prototype_type_args = [];
+      prototype_args = [];
+      prototype_ret_type =
+        type_lift
+          (String.uppercase_ascii m.interface_name)
+          prim.prim_type
+    }
+  } in
+
+  let prim_to_inj_helper prim =
+    let proto =
+      Repr.type_repr_to_prototype_repr (type_lift "m" prim.prim_type) in
+    Definition {
+      def_name = sprintf "inj_%s" prim.prim_name;
+      def_typeclass_args = [
+        sprintf
+          "Inject %s m"
+          (String.uppercase_ascii m.interface_name)
+      ];
+      def_prototype = proto;
+      def_body = fun fmt _ ->
+        fprintf fmt "inject (%s %a)"
+          (String.capitalize_ascii prim.prim_name)
+          (pp_print_list ~pp_sep:pp_print_space pp_print_string) (call_vars proto)
+    }
+  in
+
+  let interface_inductive = Inductive [{
+      inductive_name = String.uppercase_ascii m.interface_name;
+      inductive_type_args = [];
+      inductive_constructors =
+        List.map prim_to_constructor m.interface_primitives;
+      inductive_type = TMono (tlambda [type_sort_mono] type_sort_mono)
+    }]
+  in
+
+  vernacs
+  |++ [
+    Subsection "Interface datatype";
+    interface_inductive
+  ]
+  |++ List.map prim_to_inj_helper m.interface_primitives
+
+let semantics_vernac m vernacs =
+  let interface_name = String.uppercase_ascii m.interface_name in
+  let interface_type =
+    TParam (interface_name, []) in
+
+  vernacs
+  |++ [
+    Subsection "FreeSpec Semantics";
+    compacted_block_of_list @@ List.map (fun prim -> Axiom {
+      axiom_name = sprintf "unsafe_%s" prim.prim_name;
+      axiom_type = prim.prim_type;
+    }) m.interface_primitives;
+    compacted_block_of_list @@ List.map (fun prim -> ExtractConstant {
+      constant_qualid = sprintf "unsafe_%s" prim.prim_name;
+      constant_type_vars = [];
+      constant_target = qualified_name m prim.prim_name;
+    }) m.interface_primitives;
+    Definition {
+      def_name = sprintf "%s_unsafe_semantics"
+          (String.lowercase_ascii m.interface_name);
+      def_typeclass_args = [];
+      def_prototype = {
+        prototype_type_args = [];
+        prototype_args = [];
+        prototype_ret_type =
+          TMono (TParam ("semantics", [interface_type]));
+      };
+      def_body = fun fmt _ ->
+        fprintf fmt
+          "@[<v 2>bootstrap (fun a e =>@ local @[<v>match e in %s a return a with@ %a@ end@])@]"
+          interface_name
+          (pp_print_list ~pp_sep:pp_print_space
+             (fun fmt prim ->
+                let proto = type_repr_to_prototype_repr prim.prim_type in
+                let args = call_vars proto in
+                fprintf fmt "@[<hov 2>| @[<h>%s %a@]@ => @[<h>unsafe_%s %a@]@]"
+                  (String.capitalize_ascii prim.prim_name)
+                  (pp_print_list ~pp_sep:pp_print_space
+                     pp_print_string) args
+                  prim.prim_name
+                  (pp_print_list ~pp_sep:pp_print_space
+                     pp_print_string) args)) m.interface_primitives
+    }
+  ]
+
+let primitives_vernac features m vernacs =
+  let prim_to_members prim =
+    (prim.prim_name, type_lift "m" prim.prim_type) in
+
+  let monad_vernac = Typeclass {
+     class_name = sprintf "Monad%s" m.interface_name;
+     class_typeclass_args = [];
+     class_args = ["m", TMono (tlambda [type_sort_mono] type_sort_mono)];
+     class_type = type_sort;
+     class_members = List.map prim_to_members m.interface_primitives;
+   } in
+
+  vernacs
+  |++ [
+    Section "Impure Primitives";
+    Subsection "Monad Definition";
+    monad_vernac;
+  ]
+  |> is_enabled features SimpleIO @? io_primitives_vernac m
+  |> is_enabled features Interface @? interface_vernac m
+  |> is_enabled features FreeSpec @? semantics_vernac m
+
+let of_interface features models m =
+  Block
+    (of_list [
+        Comment "This file has been automatically generated by coqffi.";
+        ConfigPrologue;
+      ]
+     |> requires_vernac features models
+     |> not (empty m.interface_types) @? types_vernac features m
+     |> not (empty m.interface_functions) @? functions_vernac m
+     |> not (empty m.interface_primitives) @? primitives_vernac features m
+     |+ Comment "The generated file ends here.")

--- a/src/vernac.mli
+++ b/src/vernac.mli
@@ -1,0 +1,85 @@
+type from_require_import = {
+  import_from : string;
+  import_module : string;
+}
+
+type from_require_export = {
+  export_from : string;
+  export_module : string;
+}
+
+type require =  {
+  require_module : string;
+}
+
+type constructor = {
+  constructor_name : string;
+  constructor_prototype : Repr.prototype_repr
+}
+
+type inductive = {
+  inductive_name : string;
+  inductive_type_args : string list;
+  inductive_type : Repr.type_repr;
+  inductive_constructors : constructor list;
+}
+
+type definition = {
+  def_name : string;
+  def_typeclass_args : string list;
+  def_prototype : Repr.prototype_repr;
+  def_body : Format.formatter -> unit -> unit;
+}
+
+type typeclass = {
+  class_name : string;
+  class_typeclass_args : string list;
+  class_args : (string * Repr.type_repr) list;
+  class_type : Repr.type_repr;
+  class_members : (string * Repr.type_repr) list
+}
+
+type instance = {
+  instance_name : string;
+  instance_type : Repr.type_repr;
+  instance_members : (string * string) list
+}
+
+type axiom = {
+  axiom_name : string;
+  axiom_type : Repr.type_repr;
+}
+
+type extract_constant = {
+  constant_qualid : string;
+  constant_type_vars : string list;
+  constant_target : string;
+}
+
+type extract_inductive = {
+  inductive_qualid : string;
+  inductive_target : string;
+  inductive_variants_target : string list;
+}
+
+type t =
+  | Section of string
+  | Subsection of string
+  | Comment of string
+  | Block of t Lazylist.t
+  | CompactedBlock of t Lazylist.t
+  | ConfigPrologue
+  | FromRequireImport of from_require_import
+  | FromRequireExport of from_require_export
+  | Require of require
+  | Definition of definition
+  | Inductive of inductive list
+  | Typeclass of typeclass
+  | Instance of instance
+  | Axiom of axiom
+  | ExtractConstant of extract_constant
+  | ExtractInductive of extract_inductive
+
+val of_interface : Config.features -> string list -> Interface.t -> t
+
+val pp_vernac : Format.formatter -> t -> unit


### PR DESCRIPTION
We introduce the [Vernac] module as an additional level of
abstraction.  Now, coqffi attempts to construct a list of each
vernacular commands it has to generate prior to actually generate the
module.  There are two advantages to proceeds this way.  First, we
centralize the pretty-printing code related to vernacular commands
(whereas before, several functions were generated the same kind of
commands).  Second, if we encounter an error during the computation of
the commands to generate, we can exit prior to generating something.

Whether or not this refactoring makes the code easier to read remains
to be seen.