### PR TITLE
Remove ExtLib-specific code from the CoqFFI theory

### DIFF
--- a/examples/bin/extract.v
+++ b/examples/bin/extract.v
@@ -22,9 +22,10 @@ Extraction "cat.ml" cat_main.
 
 Definition sleep_plenty `{Monad m, MonadFile m, MonadSleep m}
   : m unit :=
+  write std_out "Hello...";;
   let x := (5 * 1 + 1 - 3) / 3 in
   sleep x;;
-  write std_out "Hello, sleepy world!".
+  write std_out " sleepy world!\n".
 
 Definition sleep_plenty_main : io_unit := IO.unsafe_run sleep_plenty.
 

--- a/theories/Data/Int.v
+++ b/theories/Data/Int.v
@@ -1,5 +1,4 @@
 From Coq Require Import NArith ZArith Int63 Program.Wf.
-From ExtLib Require Import RelDec.
 
 #[local] Close Scope nat_scope.
 #[local] Open Scope bool_scope.
@@ -59,14 +58,11 @@ Definition i63eqb (x y : i63) : bool :=
 
 Infix "=?" := i63eqb.
 
-Instance i63_RelDec : @RelDec i63 eq :=
-  { rel_dec := i63eqb }.
-
-#[refine]
-Instance i63_RelDec_Correct : RelDec_Correct i63_RelDec := {}.
+Lemma i63_eqb_eq (x y : i63) : x =? y = true <-> x = y.
 
 Proof.
-  intros [x] [y].
+  destruct x as [x].
+  destruct y as [y].
   cbv.
   split; intros equ.
   + apply eqb_correct in equ.

--- a/theories/Data/String.v
+++ b/theories/Data/String.v
@@ -4,11 +4,11 @@
 
 From Coq Require Export Ascii String.
 From Coq Require Import List Byte.
-From ExtLib Require Import Option Functor.
-From ExtLib Require Export Char.
 
-Import FunctorNotation.
 Import ListNotations.
+
+#[local]
+Infix "<$>" := option_map (at level 50).
 
 Fixpoint string_of_list_byte_fmt (i : list byte) : option string :=
   match i with


### PR DESCRIPTION
This may be provided in a separate package, but we believe it is desirable for the `CoqFFI` theory to be dependency-free.