### PR TITLE
Fix extraction of inductive constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **Fix:** Extraction of inductive constructors
+  (`-ftransparent-types`)
+
 # `coqffi.1.0.0`
 
 This is the initial release of `coqffi`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,16 @@
+# Unreleased
+
+# `coqffi.1.0.0`
+
+This is the initial release of `coqffi`.
+
+## `coqffi.1.0.0~beta1`
+
+- **Feature:** Generation of the boilerplate to use `coq-simple-io`
+  (`-fsimple-io`)
+- **Feature:** Generation of an inductive type which describes the
+  sets of impure primitives of the OCaml module interface
+  (`-finterface`)
+- **Feature:** Generation of a FreeSpec semantics (`-ffreespec`)
+- **Experimental Feature:** Generation of inductive types when
+  possible (`-ftransparent-types`)

--- a/bin/coqffi.ml
+++ b/bin/coqffi.ml
@@ -125,7 +125,7 @@ let coqffi_info =
     `S Manpage.s_bugs;
     `P "Email bug reports to <thomas.letan at ssi.gouv.fr>.";
   ] in
-  Term.(info "coqffi" ~exits:default_exits ~doc ~man ~version:"coqffi.1.0.0+dev")
+  Term.(info "coqffi" ~exits:default_exits ~doc ~man ~version:"coqffi.dev")
 
 let run_coqffi (input : string) (output : string option)
     (features : features) (models : string list) =

--- a/coq-coqffi.opam
+++ b/coq-coqffi.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "thomas.letan@ssi.gouv.fr"
-version: "1.0.0~beta1"
+version: "dev"
 
 homepage: "https://github.com/coq-community/coqffi"
 dev-repo: "git+https://github.com/coq-community/coqffi.git"

--- a/meta.yml
+++ b/meta.yml
@@ -25,7 +25,7 @@ maintainers:
 
 opam-file-maintainer: thomas.letan@ssi.gouv.fr
 
-opam-file-version: 1.0.0~beta1
+opam-file-version: dev
 
 license:
   fullname: MIT License

--- a/src/vernac.ml
+++ b/src/vernac.ml
@@ -354,7 +354,7 @@ let types_vernac features m vernacs =
         inductive_qualid = t.type_name;
         inductive_target = Interface.qualified_name m t.type_name;
         inductive_variants_target =
-          List.map (fun x -> x.variant_name) l
+          List.map (fun x -> Interface.qualified_name m x.variant_name) l
       }
     | _ ->
       ExtractConstant {


### PR DESCRIPTION
The inductive types generated by the `transparent-types` feature were not correctly extracted. More precisely, the OCaml variants where not fully qualified in the generated `Extract Inductive` vernacular command.