### PR TITLE
Generate the missing instance for the interface inductive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - **Fix:** Extraction of inductive constructors
   (`-ftransparent-types`)
+- **Fix:** Generate the missing instance for the interface inductive
+  type (`-finterface`)
 
 # `coqffi.1.0.0`
 

--- a/src/vernac.mli
+++ b/src/vernac.mli
@@ -41,6 +41,7 @@ type typeclass = {
 
 type instance = {
   instance_name : string;
+  instance_typeclass_args : string list;
   instance_type : Repr.type_repr;
   instance_members : (string * string) list
 }


### PR DESCRIPTION
During the refactoring of how the Coq code is outputted, it looks like
the [Inject]-based instance for the impure primitives monad was
forbidden. This patch fixes this by re-introducing it.

Closes #30 