### PR TITLE
Support extending the [exn] OCaml type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ This will be the initial release of `coqffi`.
 - **Feature:** Add `Seq.t` to the list of the primitive types
   supported by `coqffi`
 - **Fix:** Make sure module names are always capitalized
+- **Feature**: In presence of a constuction of the form `exception Foo
+  of bar`, coqffi now generates a “proxy” type `FooExn`, along with
+  conversion functions from and to `exn`, and an instance for the
+  `Exn` typeclass provided by the `CoqFFI` theory.
 
 ## `coqffi.1.0.0~beta2`
 

--- a/bin/coqffi.ml
+++ b/bin/coqffi.ml
@@ -121,11 +121,11 @@ let coqffi_info =
       feature needs to be enabled). It is disable by default."
     );
 
-    `S "EXTRACTION PROFILES";
+    `S "SUPPORTED TYPES";
 
     `P "In addition to tuples and types introduced in the input module,
         $(b,coqffi) supports the following base types:";
-    `Noblank;
+
     `Pre "  - $(b,bool)"; `Noblank;
     `Pre "  - $(b,char)"; `Noblank;
     `Pre "  - $(b,int)"; `Noblank;
@@ -134,6 +134,12 @@ let coqffi_info =
     `Pre "  - $(i,'a) $(b,option)"; `Noblank;
     `Pre "  - $(b,string)"; `Noblank;
     `Pre "  - $(b,unit)"; `Noblank;
+    `Pre "  - $(b,exn)";
+    `P "Besides, $(b,coqffi) also supports extending the $(b,exn)
+    type, using the $(i,exception )$(b,Foo)$(i, of ) $(b,bar)
+    construction. In such a case, $(b,coqffi) will generate a “proxy”
+    inductive type $(b,FooExn), along with conversion functions from
+    and to $(b,exn).";
     `S Manpage.s_bugs;
     `P "Email bug reports to <thomas.letan at ssi.gouv.fr>.";
   ] in

--- a/examples/src/dune
+++ b/examples/src/dune
@@ -33,6 +33,10 @@
   (target Str.v)
   (action (run coqffi -r Examples.StrModels -finterface %{cmi:str} -o %{target})))
 
+(rule
+  (target Exn.v)
+  (action (run coqffi -finterface %{cmi:exn} -o %{target})))
+
 (coq.theory
   (name Examples)
   (theories CoqFFI))

--- a/examples/src/exn.ml
+++ b/examples/src/exn.ml
@@ -1,0 +1,2 @@
+type bar = int
+exception Foo of bar

--- a/examples/src/exn.mli
+++ b/examples/src/exn.mli
@@ -1,0 +1,2 @@
+type bar
+exception Foo of bar

--- a/src/entry.mli
+++ b/src/entry.mli
@@ -29,10 +29,16 @@ type type_entry = {
 
 type mutually_recursive_types_entry = type_entry list
 
+type exception_entry = {
+  exception_name : string;
+  exception_args : mono_type_repr list;
+}
+
 type entry =
   | EPrim of primitive_entry
   | EFunc of function_entry
   | EType of type_entry
+  | EExn of exception_entry
 
 val entry_of_signature : Config.features -> Types.signature_item -> entry
 

--- a/src/interface.mli
+++ b/src/interface.mli
@@ -7,6 +7,7 @@ type t = {
   interface_types : type_entry list;
   interface_functions : function_entry list;
   interface_primitives : primitive_entry list;
+  interface_exceptions : exception_entry list;
 }
 
 val empty_interface : string -> t

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -20,3 +20,4 @@ let types_table =
   |> preserve "option"
   |> preserve "string"
   |> preserve "unit"
+  |> preserve "exn"

--- a/theories/Exn.v
+++ b/theories/Exn.v
@@ -1,0 +1,11 @@
+From Coq Require Extraction.
+
+Axiom exn : Type.
+
+Class Exn (e : Type) := { to_exn : e -> exn
+                        ; of_exn : exn -> option e
+                        }.
+
+Module ExnExtraction.
+  Extract Constant exn => "exn".
+End ExnExtraction.

--- a/theories/Extraction.v
+++ b/theories/Extraction.v
@@ -34,3 +34,8 @@ Extract Inductive list => "list" [ "[]" "( :: )" ].
 
 From CoqFFI Require Export Seq.
 Import SeqExtraction.
+
+(** Exceptions *)
+
+From CoqFFI Require Export Exn.
+Import ExnExtraction.


### PR DESCRIPTION
    In presence of a constuction of the form [exception Foo of bar],
    coqffi now generates a “proxy” type [FooExn], along with conversion
    functions from and to [exn], and an instance for the [Exn] typeclass
    provided by the [CoqFFI] theory.

_______________________________ 

This is a first step towards supporting exceptions in `coqffi`. The next step will be to provide an annotation to tell `coqffi` that a function can throw an exception, and act accordingly.

```ocaml
type bar
exception Foo of bar
```

gives

```coq
(* This file has been generated by coqffi. *)

Set Implicit Arguments.
Unset Strict Implicit.
Set Contextual Implicit.
Generalizable All Variables.

From CoqFFI Require Export Extraction.
From SimpleIO Require Import IO_Monad.
From CoqFFI Require Import Interface.

(** * Types *)

Axiom bar : Type.

Extract Constant bar => "Examples.Exn.bar".

(** * OCaml Exceptions *)

(** ** [Foo] *)

Inductive FooExn : Type :=
| MakeFooExn (x0 : bar) : FooExn.

Axiom exn_of_foo : FooExn -> exn.
Axiom foo_of_exn : exn -> option FooExn.

Extract Constant exn_of_foo => "(function | MakeFooExn x0 => Foo x0)".
Extract Constant foo_of_exn
  => "(function | Foo x0 => Some (MakeFooExn x0) | _ => None)".

Instance FooExn_Exn : Exn FooExn :=
  { to_exn := exn_of_foo
  ; of_exn := foo_of_exn
  }.

(* The generated file ends here. *)
```
