### PR TITLE
Stop importing [Data.Seq] in [Extraction]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ This will be the initial release of `coqffi`.
 - **Breaking Change:** The `coq_model` attribute implies the marked
   value is pure (it was previously ignored when used in conjuction
   with the `impure` attribute)
+- **Breaking Change:** The `CoqFFI.Extraction` module does not
+  export the `CoqFFI.Data.Seq` module anymore
 - **Feature:** Add a new feature to assume all OCaml values of
   the input OCaml module interface are pure (`-fpure-module`)
 - **Feature:** Add `Seq.t` to the list of the primitive types

--- a/examples/bin/extract.v
+++ b/examples/bin/extract.v
@@ -3,10 +3,11 @@ From SimpleIO Require Import SimpleIO.
 From ExtLib Require Import Monad.
 Import MonadLetNotation.
 Open Scope monad_scope.
-From CoqFFI Require Import Int Seq.
+From CoqFFI Require Import Extraction.
 Open Scope i63_scope.
 
 From Examples Require Import File Sleep.
+From CoqFFI Require Import String.
 
 Generalizable All Variables.
 

--- a/theories/Extraction.v
+++ b/theories/Extraction.v
@@ -5,7 +5,7 @@ Import IntExtraction.
 
 (** ** Strings *)
 
-From CoqFFI Require Export String.
+From Coq Require Export Ascii String.
 From Coq Require Import ExtrOcamlNativeString.
 
 (** ** Booleans *)
@@ -32,8 +32,8 @@ Extract Inductive list => "list" [ "[]" "( :: )" ].
 
 (** ** Seq *)
 
-From CoqFFI Require Export Seq.
-Import SeqExtraction.
+From CoqFFI Require Seq.
+Import Seq.SeqExtraction.
 
 (** Exceptions *)
 


### PR DESCRIPTION
The [Data.Seq] module as a function called [ret], which has a name
conflict with the [ret] function of the [Monad] typeclass.