### PR TITLE
Support aliases for Coq reserved keywords and OCaml operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,9 @@ This will be the initial release of `coqffi`.
 - **Feature:** ~coqffi~ will no longer abort when confronting an input
   it cannot handle, but will rather print a warning explaining why
   a given entry will not be part of the generated Coq module
-- **Features:** ~coqffi~ now supports signature modules
+- **Feature:** ~coqffi~ now supports signature modules
+- **Feature:** ~coqffi~ now uses aliases for some OCaml operators,
+  and Gallina reserved keywords
 - **Fix:** Make sure module names are always capitalized
 
 ## `coqffi.1.0.0~beta2`

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -6,7 +6,7 @@ let process models features input ochannel =
   read_cmi input
   |> Mod.of_cmi_infos ~features
   |> Mod.translate Translation.types_table
-  |> Vernac.of_mod features models
+  |> Vernac.of_mod Alias.default features models
   |> Format.fprintf ochannel "%a@?" Vernac.pp_vernac
 
 exception TooManyArguments

--- a/examples/src/aliases.ml
+++ b/examples/src/aliases.ml
@@ -1,0 +1,4 @@
+type t = int
+
+let (+) x y = x + y
+let (<) x y = x < y

--- a/examples/src/aliases.mli
+++ b/examples/src/aliases.mli
@@ -1,0 +1,4 @@
+type t
+
+val (+) : t -> t -> t
+val (<) : t -> t -> bool [@@pure]

--- a/examples/src/dune
+++ b/examples/src/dune
@@ -45,6 +45,10 @@
   (target Modules.v)
   (action (run coqffi -finterface %{cmi:modules} -ffreespec -o %{target})))
 
+(rule
+  (target Aliases.v)
+  (action (run coqffi -finterface %{cmi:aliases} -ffreespec -o %{target})))
+
 (coq.theory
   (name Examples)
   (theories CoqFFI))

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -1,0 +1,44 @@
+type t = {
+    alias_coq : string;
+    alias_operator : bool;
+  }
+
+module Table = Map.Make(String)
+
+type table = t Table.t
+
+let add_operator ~ocaml ~coq tbl =
+  Table.add ocaml {
+      alias_coq = coq ;
+      alias_operator = true;
+    } tbl
+
+let add_keyword ~ocaml ~coq tbl =
+  Table.add ocaml {
+      alias_coq = coq ;
+      alias_operator = false;
+    } tbl
+
+let default =
+  Table.empty
+  |> add_operator ~ocaml:"+" ~coq:"add"
+  |> add_operator ~ocaml:"-" ~coq:"sub"
+  |> add_operator ~ocaml:"*" ~coq:"mul"
+  |> add_operator ~ocaml:"/" ~coq:"div"
+  |> add_operator ~ocaml:"=" ~coq:"eqb"
+  |> add_operator ~ocaml:"<>" ~coq:"neqb"
+  |> add_operator ~ocaml:"<" ~coq:"ltb"
+  |> add_operator ~ocaml:"<=" ~coq:"leb"
+  |> add_operator ~ocaml:">" ~coq:"gtb"
+  |> add_operator ~ocaml:">=" ~coq:"geb"
+  |> add_keyword ~ocaml:"return" ~coq:"ret"
+
+let ocaml_name t orig =
+  match Table.find_opt orig t with
+  | Some { alias_coq = _; alias_operator = true } -> Format.sprintf "(%s)" orig
+  | _ -> orig
+
+let coq_name t orig =
+  match Table.find_opt orig t with
+  | Some alias -> alias.alias_coq
+  | _ -> orig

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -1,0 +1,14 @@
+type t = {
+    alias_coq : string;
+    alias_operator : bool;
+  }
+
+type table
+
+val default : table
+
+val add_operator : ocaml:string -> coq:string -> table -> table
+val add_keyword : ocaml:string -> coq:string -> table -> table
+
+val ocaml_name : table -> string -> string
+val coq_name : table -> string -> string

--- a/src/vernac.mli
+++ b/src/vernac.mli
@@ -82,6 +82,6 @@ type t =
   | ExtractConstant of extract_constant
   | ExtractInductive of extract_inductive
 
-val of_mod : Feature.features -> string list -> Mod.t -> t
+val of_mod : Alias.table -> Feature.features -> string list -> Mod.t -> t
 
 val pp_vernac : Format.formatter -> t -> unit


### PR DESCRIPTION
    Operators (i.e., entries of the form [val (+) : t -> t -> t]) are now
    supported correctly by coqffi. As of now, arithmetic operators are
    supported. Similarly, the introduced alias mechanism allows for
    dealing with reserved keywords in Gallian, like [return].
    
    The list provided in the [Alias] module is minimal, and should be
    extended prior to the 1.0.0 release.

Fixes #37