### PR TITLE
Support higher-order primitives in the Lwt feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 This will be the initial release of `coqffi`.
 
+## Unreleased
+
+- **Breaking Change:** `coqffi` support of `Lwt` has been improved. It
+  now handles “higher-order primitives” —that is, primitives where the
+  `Lwt.t` not only appaers in the head position of the return type,
+  but also in their arguments for instance— more smoothly.
+
 ## `coqffi.1.0.0~beta5`
 
 - **Dependencies** Support Coq 8.13 in addition to Coq 8.12

--- a/examples/src/async.ml
+++ b/examples/src/async.ml
@@ -1,2 +1,4 @@
 let sync_computation x = x
 let async_computation x = Lwt.return x
+let bind = Lwt.bind
+let join = Lwt.return (Lwt.return 2)

--- a/examples/src/async.mli
+++ b/examples/src/async.mli
@@ -1,2 +1,5 @@
 val sync_computation : 'a -> 'a
+
 val async_computation : 'a -> 'a Lwt.t
+val bind : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+val join : int Lwt.t Lwt.t

--- a/examples/src/dune
+++ b/examples/src/dune
@@ -61,7 +61,7 @@
 
 (rule
   (target Async.v)
-  (action (run coqffi -flwt -r Examples.Lwt -finterface %{cmi:async} -ffreespec -o %{target})))
+  (action (run coqffi -flwt -r Examples.Lwt %{cmi:async} -ffreespec -o %{target})))
 
 (rule
   (targets M1.v M1.ffi)

--- a/src/entry.mli
+++ b/src/entry.mli
@@ -10,6 +10,7 @@ type primitive_entry = {
 }
 
 type lwt_entry = {
+  lwt_placeholder : int;
   lwt_name : string;
   lwt_type : type_repr;
   lwt_loc : Location.t;

--- a/src/feature.ml
+++ b/src/feature.ml
@@ -62,5 +62,5 @@ let check_features_consistency lwt_alias lf ~wduplicate =
   | Some lwt_alias, Some true -> (Some lwt_alias, lf)
   | Some _, Some false -> raise LwtExplicitelyDisableButLwtAliasSet
   | Some lwt_alias, None -> (Some lwt_alias, (Lwt, true) :: lf)
-  | None, Some true -> (Some "Lwt.t", lf)
+  | None, Some true -> (Some "Lwt", lf)
   | _, _ -> (None, lf)

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -175,8 +175,8 @@ and segment_module_intro_aux ~rev_namespace tbl acc = function
       let (tbl, rst) = segment_module_intro ~rev_namespace tbl l in
       (tbl, List.concat typs @ rst)
 
-let of_cmi_infos ~translations ~features ~lwt_alias (info : cmi_infos) =
+let of_cmi_infos ~translations ~features ~lwt_module (info : cmi_infos) =
   let (namespace, name) = namespace_and_path info.cmi_name in
-  module_of_signatures features lwt_alias namespace name info.cmi_sign
+  module_of_signatures features lwt_module namespace name info.cmi_sign
   |> of_module_entry translations
   |> snd

--- a/src/mod.mli
+++ b/src/mod.mli
@@ -16,7 +16,7 @@ and intro =
   | Right of mutually_recursive_types_entry
   | Left of t
 
-val of_cmi_infos : translations:Translation.t -> features:features -> lwt_alias:(string option) -> Cmi_format.cmi_infos -> t
+val of_cmi_infos : translations:Translation.t -> features:features -> lwt_module:(string option) -> Cmi_format.cmi_infos -> t
 
 val qualified_name : t -> string -> string
 

--- a/src/vernac.mli
+++ b/src/vernac.mli
@@ -48,6 +48,7 @@ type instance = {
 
 type axiom = {
   axiom_name : string;
+  axiom_typeclass_args : string list;
   axiom_type : Repr.type_repr;
 }
 
@@ -87,6 +88,6 @@ and t =
   | ExtractConstant of extract_constant
   | ExtractInductive of extract_inductive
 
-val of_mod : Alias.table -> Feature.features -> string list -> Mod.t -> t
+val of_mod : string option -> Alias.table -> Feature.features -> string list -> Mod.t -> t
 
 val pp_vernac : Format.formatter -> t -> unit


### PR DESCRIPTION
With this patch, we greatly improve the support for Lwt by dealing
with so-called higher-order primitives, where the [Lwt.t] type was not
only appearing as the head position of the return type (e.g. ['a
Lwt.t]), but also elsewhere (for instance, in one of its arguments).

Previously, only the head [Lwt.t] of the return type was generalize in
the typeclass, so for instance, [bind] would have been translated as
follows:

    Lwt.t a -> (a -> Lwt.t b) -> m a

With this patch, the other [Lwt.t] are also generalized

    m a -> (a -> m b) -> m a

To implement that, I had to modify how the primitive monadification
was handle. In particular, this lead to the introduction of the notion
of [Placeholder] that can be injected and later filled.

Finally, this patch paves the road towards supporting higher-order
primitives in synchronous interfaces too.

Fixes #63 