### PR TITLE
Refine the generation of typeclass instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@ This will be the initial release of `coqffi`.
 - **Fix:** `coqffi` now generates typeclass instances that Coq can
   better typecheck. The previous generation was mostly correct, but
   there were some erroneous cases that were hard to characterize. This
-  is why the new generation is systematically used, instead of only
-  when required.
+  is why the new generation is systematically used for polymorphic
+  primitives, instead of only when required.
 
 ## `coqffi.1.0.0~beta5`
 

--- a/src/vernac.ml
+++ b/src/vernac.ml
@@ -281,7 +281,7 @@ let call_vars proto =
 let instance_member_body proto name =
   let tvars = proto.prototype_type_args in
   let vars = call_vars proto in
-  if 0 < List.length vars + List.length tvars then
+  if 0 < List.length tvars then
     asprintf "@[<h 2>fun%a%a@ => %s%a@]"
       (pp_list
          ~pp_prefix:(fun fmt _ -> pp_print_text fmt " ")


### PR DESCRIPTION
We only need to generate a lambda if the primitive is polymorphic, not
every time.