### PR TITLE
Fix the generation of Coq record

### DIFF
--- a/examples/bin/extract.v
+++ b/examples/bin/extract.v
@@ -6,7 +6,8 @@ Open Scope monad_scope.
 From CoqFFI Require Import Extraction.
 Open Scope i63_scope.
 
-From Examples Require Import File Sleep.
+From Examples Require Import File Sleep Records.
+Import M.
 From CoqFFI Require Import String.
 
 Generalizable All Variables.
@@ -21,13 +22,15 @@ Definition cat_main : io_unit := IO.unsafe_run cat.
 
 Extraction "cat.ml" cat_main.
 
-Definition sleep_plenty `{Monad m, MonadFile m, MonadSleep m}
+Definition sleep_plenty `{Monad m, MonadFile m, MonadSleep m} (d : i63)
   : m unit :=
   write std_out "Hello...";;
-  let x := (5 * 1 + 1 - 3) / 3 in
+  let x := (5 * 1 + 1 - 3) / d in
   sleep x;;
   write std_out " sleepy world!\n".
 
-Definition sleep_plenty_main : io_unit := IO.unsafe_run sleep_plenty.
+Definition sleep_plenty_main : io_unit :=
+  let x := {| f1 := 1; f2 := 2 |} in
+  IO.unsafe_run (sleep_plenty (x.(f1) + x.(f2))).
 
 Extraction "sleep_plenty.ml" sleep_plenty_main.

--- a/examples/src/records.ml
+++ b/examples/src/records.ml
@@ -5,3 +5,7 @@ type u = U of t
 type 'a v = { foobar : 'a; moo : t }
 
 type w = W of { noo : int }
+
+module M = struct
+  type t = { f1 : int; f2 : int }
+end

--- a/examples/src/records.mli
+++ b/examples/src/records.mli
@@ -5,3 +5,7 @@ type u = U of t
 type 'a v = { foobar : 'a; moo : t }
 
 type w = W of { noo : int }
+
+module M : sig
+  type t = { f1 : int; f2 : int }
+end

--- a/src/vernac.ml
+++ b/src/vernac.ml
@@ -1111,6 +1111,7 @@ and intros_vernac lwt_module aliases features models m vernacs =
                     };
                 ]
             | Record r, None, true ->
+                let ns = String.concat "." m.mod_namespace in
                 ExtractInductive
                   {
                     inductive_qualid = t.type_name;
@@ -1123,7 +1124,14 @@ and intros_vernac lwt_module aliases features models m vernacs =
                               (fun fmt f -> pp_print_text fmt f.field_name))
                            r
                        in
-                       [ asprintf "(fun (%s) -> { %s })" tuple tuple ]);
+                       let fields =
+                         asprintf "%a"
+                           (pp_list
+                              ~pp_sep:(fun fmt _ -> fprintf fmt "; ")
+                              (fun fmt f -> pp_print_text fmt f.field_name))
+                           r
+                       in
+                       [ sprintf "%s.(fun (%s) -> { %s })" ns tuple fields ]);
                   }
                 ::
                 List.map
@@ -1133,7 +1141,7 @@ and intros_vernac lwt_module aliases features models m vernacs =
                         constant_qualid = f.field_name;
                         constant_type_vars = [];
                         constant_target =
-                          asprintf "(fun x -> x.%s)" f.field_name;
+                          asprintf "%s.(fun x -> x.%s)" ns f.field_name;
                       })
                   r
             | _ ->


### PR DESCRIPTION
The previous patch was not perfect, far from it even. This patch fixes
the main issues, and ensures everything works by using records in one
of the binary examples.

This is another proof, if needed, that the current way we test coqffi
is not enough (and that compiling a Coq module using Extraction
commands is not remotely a guarantee that we are doing something
well).