### PR TITLE
Fix support for labelled and optional arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ This will be the initial release of `coqffi`.
   now handles “higher-order primitives” —that is, primitives where the
   `Lwt.t` not only appaers in the head position of the return type,
   but also in their arguments for instance— more smoothly (`-flwt`)
-- **Feature:** Support labelled arguments
+- **Feature:** Support labelled and optional arguments
 - **Feature:** Support primitive floats
 - **Feature:** Support 32bits signed integers
 - **Feature:** `coqffi` can now generate equivalent Coq types for

--- a/src-prepare.sh
+++ b/src-prepare.sh
@@ -11,7 +11,7 @@ case "${ocaml_version}" in
 esac
 
 case "${coq_version}" in
-    8.14) true ;; # this is the dev version of coq
+    8.15 | 8.14) true ;; # dev versions
     8.13) true ;;
     8.12) patch -p1 -u < patches/coq.8.12.patch ;;
     *) echo "unsupported Coq version ${coq_version}"; exit 1 ;;

--- a/src/entry.ml
+++ b/src/entry.ml
@@ -166,8 +166,8 @@ let rec exclude cmp l1 l2 =
 let prototype_of_constructor params_type args ret =
   let typify acc t =
     match type_repr_of_type_expr t with
-    | TPoly (p, t) -> (p @ acc, (None, TMono t))
-    | t -> (acc, (None, t))
+    | TPoly (p, t) -> (p @ acc, (PositionedArg 0, TMono t))
+    | t -> (acc, (PositionedArg 0, t))
   in
 
   let monoify = function TPoly (p, t) -> (p, TMono t) | t -> ([], t) in

--- a/src/pp.ml
+++ b/src/pp.ml
@@ -15,13 +15,19 @@ let not_empty = function _ :: _ -> true | _ -> false
 
 let pp_if_not_empty pp fmt l = if not_empty l then pp fmt ()
 
+let pp_arg_name fmt = function
+  | PositionedArg pos -> fprintf fmt "x%d" pos
+  | LabeledArg name | OptionalArg name -> fprintf fmt "%s" name
+
+let pp_arg_call fmt = function
+  | PositionedArg pos -> fprintf fmt "x%d" pos
+  | LabeledArg name -> fprintf fmt "~%s" name
+  | OptionalArg name -> fprintf fmt "?%s" name
+
 let pp_args_list fmt args_list =
-  let idx = ref 0 in
   pp_print_list ~pp_sep:pp_print_space
-    (fun fmt (_, arg) ->
-      let x = !idx in
-      fprintf fmt "(x%d : %a)" x pp_type_repr arg;
-      idx := x + 1)
+    (fun fmt (argtyp, arg) ->
+      fprintf fmt "(%a : %a)" pp_arg_name argtyp pp_type_repr arg)
     fmt args_list
 
 let pp_type_args_list fmt type_args_list =

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -14,7 +14,12 @@ val pp_list :
   'a list ->
   unit
 
-val pp_args_list : formatter -> (string option * Repr.type_repr) list -> unit
+val pp_arg_name : formatter -> Repr.argument_type -> unit
+
+val pp_arg_call : formatter -> Repr.argument_type -> unit
+
+val pp_args_list :
+  formatter -> (Repr.argument_type * Repr.type_repr) list -> unit
 
 val pp_type_args_list : formatter -> string list -> unit
 

--- a/src/repr.mli
+++ b/src/repr.mli
@@ -9,9 +9,14 @@
 
 type constant_repr = CPlaceholder of int | CName of string
 
+type argument_type =
+  | PositionedArg of int
+  | LabeledArg of string
+  | OptionalArg of string
+
 type mono_type_repr =
   | TLambda of {
-      label : string option;
+      argtype : argument_type;
       domain : mono_type_repr;
       codomain : mono_type_repr;
     }
@@ -121,7 +126,7 @@ val type_sort : type_repr
 
 type prototype_repr = {
   prototype_type_args : string list;
-  prototype_args : (string option * type_repr) list;
+  prototype_args : (argument_type * type_repr) list;
   prototype_ret_type : type_repr;
 }
 


### PR DESCRIPTION
The previous patch introduces a number of issues that we needed be
fixed.  This is achieved with the present patch.  One issue remaining
is the fact that there might be a collusion between named and
positioned arguments, more precisely that if a named argument is of
the form `x[0-9]+`, it is likely that an issue will arise.