### PR TITLE
Name functions arguments in Coq based on their position alone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ This will be the initial release of `coqffi`.
 ## Unreleased
 
 - **Dependencies:** Support OCaml 4.12
+- **Fix:** Name functions arguments in Coq based on their position
+  alone, to reduce the risk to have a naming clash between polymorphic
+  type name and labeled arguments.
 
 ## `coqffi.1.0.0~beta6`
 

--- a/src/entry.ml
+++ b/src/entry.ml
@@ -166,8 +166,9 @@ let rec exclude cmp l1 l2 =
 let prototype_of_constructor params_type args ret =
   let typify acc t =
     match type_repr_of_type_expr t with
-    | TPoly (p, t) -> (p @ acc, (PositionedArg 0, TMono t))
-    | t -> (acc, (PositionedArg 0, t))
+    | TPoly (p, t) ->
+        (p @ acc, ({ position = 0; kind = PositionedArg }, TMono t))
+    | t -> (acc, ({ position = 0; kind = PositionedArg }, t))
   in
 
   let monoify = function TPoly (p, t) -> (p, TMono t) | t -> ([], t) in

--- a/src/pp.ml
+++ b/src/pp.ml
@@ -15,14 +15,13 @@ let not_empty = function _ :: _ -> true | _ -> false
 
 let pp_if_not_empty pp fmt l = if not_empty l then pp fmt ()
 
-let pp_arg_name fmt = function
-  | PositionedArg pos -> fprintf fmt "x%d" pos
-  | LabeledArg name | OptionalArg name -> fprintf fmt "%s" name
+let pp_arg_name fmt { position; _ } = fprintf fmt "x%d" position
 
-let pp_arg_call fmt = function
-  | PositionedArg pos -> fprintf fmt "x%d" pos
-  | LabeledArg name -> fprintf fmt "~%s" name
-  | OptionalArg name -> fprintf fmt "?%s" name
+let pp_arg_call fmt { position; kind } =
+  match kind with
+  | PositionedArg -> fprintf fmt "x%d" position
+  | LabeledArg name -> fprintf fmt "~%s:x%d" name position
+  | OptionalArg name -> fprintf fmt "?%s:x%d" name position
 
 let pp_args_list fmt args_list =
   pp_print_list ~pp_sep:pp_print_space

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -14,12 +14,11 @@ val pp_list :
   'a list ->
   unit
 
-val pp_arg_name : formatter -> Repr.argument_type -> unit
+val pp_arg_name : formatter -> Repr.argument -> unit
 
-val pp_arg_call : formatter -> Repr.argument_type -> unit
+val pp_arg_call : formatter -> Repr.argument -> unit
 
-val pp_args_list :
-  formatter -> (Repr.argument_type * Repr.type_repr) list -> unit
+val pp_args_list : formatter -> (Repr.argument * Repr.type_repr) list -> unit
 
 val pp_type_args_list : formatter -> string list -> unit
 

--- a/src/repr.mli
+++ b/src/repr.mli
@@ -9,14 +9,16 @@
 
 type constant_repr = CPlaceholder of int | CName of string
 
-type argument_type =
-  | PositionedArg of int
+type argument_kind =
+  | PositionedArg
   | LabeledArg of string
   | OptionalArg of string
 
+type argument = { position : int; kind : argument_kind }
+
 type mono_type_repr =
   | TLambda of {
-      argtype : argument_type;
+      argtype : argument;
       domain : mono_type_repr;
       codomain : mono_type_repr;
     }
@@ -126,7 +128,7 @@ val type_sort : type_repr
 
 type prototype_repr = {
   prototype_type_args : string list;
-  prototype_args : (argument_type * type_repr) list;
+  prototype_args : (argument * type_repr) list;
   prototype_ret_type : type_repr;
 }
 

--- a/src/vernac.ml
+++ b/src/vernac.ml
@@ -454,7 +454,7 @@ let ind_type =
     else
       TLambda
         {
-          argtype = PositionedArg pos;
+          argtype = { position = pos; kind = PositionedArg };
           domain = type_sort_mono;
           codomain = aux (pos + 1) (arity - 1);
         }
@@ -952,7 +952,7 @@ let exceptions_vernac ~rev_namespace conflicts m vernacs =
             TMono
               (TLambda
                  {
-                   argtype = PositionedArg 0;
+                   argtype = { position = 0; kind = PositionedArg };
                    domain = proxy_type;
                    codomain = exn_type;
                  });
@@ -967,7 +967,7 @@ let exceptions_vernac ~rev_namespace conflicts m vernacs =
             TMono
               (TLambda
                  {
-                   argtype = PositionedArg 0;
+                   argtype = { position = 0; kind = PositionedArg };
                    domain = exn_type;
                    codomain = TParam (CName "option", [ proxy_type ]);
                  });


### PR DESCRIPTION
This is to avoid a situation where you can have a polymorphic type and
an argument label sharing the same name.