### PR TITLE
Rename `tupN` into `tuplN` to avoid name clashes with data-encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ This will be the initial release of `coqffi`.
 - **Breaking Change:** `coqffi` now correctly handles tuples, whereas
   in previous versions the extraction of tuples of more than 2
   elements was broken.  Only tuples up to 20 elements are supported.
+- **Breaking Change:** `Rename `tupN` into `tuplN` to avoid
+  unfortunate shadowing with `data-encoding`
 - **Dependencies:** Support OCaml 4.13 and 4.14
 - **Fix:** Extraction commands for asynchronous primitives were not
   handling labelled arguments correctly.

--- a/examples/bin/extract.v
+++ b/examples/bin/extract.v
@@ -25,9 +25,9 @@ Extraction "cat.ml" cat_main.
 Definition sleep_plenty `{Monad m, MonadFile m, MonadSleep m} (d : i63)
   : m unit :=
   write std_out "Hello...";;
-  let y : tup4 i63 i63 i63 i63 := mktup4 1 2 3 4 in
+  let y : tupl4 i63 i63 i63 i63 := mktupl4 1 2 3 4 in
   match y with
-  | mktup4 a b c d =>
+  | mktupl4 a b c d =>
     let x := (a * b + c - d) / d in
     sleep x;;
     write std_out " sleepy world!\n"

--- a/shim/gen_shim.ml
+++ b/shim/gen_shim.ml
@@ -5,7 +5,7 @@ let rec ( -- ) x y = if x < y then x :: (x + 1 -- y) else [ y ]
 
 let pp_tuple_def fmt n =
   let pp_poly_type fmt n = fprintf fmt "'a%d" n in
-  fprintf fmt "@[<v 2>type (%a) tup%n =@ %a@]"
+  fprintf fmt "@[<v 2>type (%a) tupl%n =@ %a@]"
     (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_string fmt ", ") pp_poly_type)
     (1 -- n) n
     (pp_print_list

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -53,8 +53,9 @@ let types_table =
     List.fold_left
       (fun ns x ->
         Namespace.translate
-          ~ocaml:(Format.sprintf "Coq_coqffi.Shim.tup%d" x)
-          ~coq:(Format.sprintf "tup%d" x) ns)
+          ~ocaml:(Format.sprintf "Coq_coqffi.Shim.tupl%d" x)
+          ~coq:(Format.sprintf "tupl%d" x)
+          ns)
       ns l
   in
   let ns =

--- a/theories/gen_tuple.ml
+++ b/theories/gen_tuple.ml
@@ -37,7 +37,8 @@ let pp_term_args fmt l =
 
 let pp_inductive fmt n =
   fprintf fmt
-    "@[<v>Inductive tup%d (%a : Type) :=@ @[<v 2>| mktup%d %a@ : tup%d %a.@]@]"
+    "@[<v>Inductive tupl%d (%a : Type) :=@ @[<v 2>| mktupl%d %a@ : tupl%d \
+     %a.@]@]"
     n pp_poly_args (1 -- n) n
     (pp_print_list
        ~pp_sep:(fun fmt _ -> pp_print_string fmt " ")
@@ -45,7 +46,7 @@ let pp_inductive fmt n =
     (1 -- n) n pp_poly_args (1 -- n)
 
 let pp_arguments fmt n =
-  fprintf fmt "@[<v>Arguments mktup%d [%a] (%a).@]" n pp_poly_args (1 -- n)
+  fprintf fmt "@[<v>Arguments mktupl%d [%a] (%a).@]" n pp_poly_args (1 -- n)
     pp_term_args (1 -- n)
 
 let pp_prod_arg fmt n =
@@ -57,13 +58,13 @@ let pp_prod_arg fmt n =
 
 let pp_instance fmt n =
   fprintf fmt
-    "@[<v 2>Instance tup%d_of_prod {%a}@ : _OfProd (%a) (tup%d %a) := @ %a.@]" n
-    pp_poly_args (1 -- n)
+    "@[<v 2>Instance tupl%d_of_prod {%a}@ : _OfProd (%a) (tupl%d %a) := @ %a.@]"
+    n pp_poly_args (1 -- n)
     (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_string fmt " * ") pp_poly_arg)
     (1 -- n) n pp_poly_args (1 -- n)
     (fun fmt _ ->
       fprintf fmt
-        "@[<v>{ of_prod := fun '%a => mktup%d %a@ ; to_prod := fun '(mktup%d \
+        "@[<v>{ of_prod := fun '%a => mktupl%d %a@ ; to_prod := fun '(mktupl%d \
          %a) => %a }@]"
         pp_prod_arg n n pp_term_args (1 -- n) n pp_term_args (1 -- n)
         pp_prod_arg n)
@@ -76,7 +77,7 @@ let pp_extraction fmt n =
     (pp_print_list
        ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ")
        (fun fmt n ->
-         fprintf fmt "Extract Inductive tup%d => \"Shim.tup%d\" [ \"\" ]." n n))
+         fprintf fmt "Extract Inductive tupl%d => \"Shim.tupl%d\" [ \"\" ]." n n))
     (3 -- n)
 
 let _ =


### PR DESCRIPTION
The underlying issue (poor support for shadowing of primitive types)
remains, but at least we won’t trigger it when using coqffi with a
project relying on data-encoding.