### PR TITLE
Rename [tuplN] into [tupleN] because it's nicer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ This will be the initial release of `coqffi`.
 - **Breaking Change:** `coqffi` now correctly handles tuples, whereas
   in previous versions the extraction of tuples of more than 2
   elements was broken.  Only tuples up to 20 elements are supported.
-- **Breaking Change:** `Rename `tupN` into `tuplN` to avoid
+- **Breaking Change:** `Rename `tupN` into `tupleN` to avoid
   unfortunate shadowing with `data-encoding`
 - **Dependencies:** Support OCaml 4.13 and 4.14
 - **Fix:** Extraction commands for asynchronous primitives were not

--- a/examples/bin/extract.v
+++ b/examples/bin/extract.v
@@ -25,9 +25,9 @@ Extraction "cat.ml" cat_main.
 Definition sleep_plenty `{Monad m, MonadFile m, MonadSleep m} (d : i63)
   : m unit :=
   write std_out "Hello...";;
-  let y : tupl4 i63 i63 i63 i63 := mktupl4 1 2 3 4 in
+  let y : tuple4 i63 i63 i63 i63 := mktuple4 1 2 3 4 in
   match y with
-  | mktupl4 a b c d =>
+  | mktuple4 a b c d =>
     let x := (a * b + c - d) / d in
     sleep x;;
     write std_out " sleepy world!\n"

--- a/shim/gen_shim.ml
+++ b/shim/gen_shim.ml
@@ -5,7 +5,7 @@ let rec ( -- ) x y = if x < y then x :: (x + 1 -- y) else [ y ]
 
 let pp_tuple_def fmt n =
   let pp_poly_type fmt n = fprintf fmt "'a%d" n in
-  fprintf fmt "@[<v 2>type (%a) tupl%n =@ %a@]"
+  fprintf fmt "@[<v 2>type (%a) tuple%n =@ %a@]"
     (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_string fmt ", ") pp_poly_type)
     (1 -- n) n
     (pp_print_list

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -53,8 +53,8 @@ let types_table =
     List.fold_left
       (fun ns x ->
         Namespace.translate
-          ~ocaml:(Format.sprintf "Coq_coqffi.Shim.tupl%d" x)
-          ~coq:(Format.sprintf "tupl%d" x)
+          ~ocaml:(Format.sprintf "Coq_coqffi.Shim.tuple%d" x)
+          ~coq:(Format.sprintf "tuple%d" x)
           ns)
       ns l
   in

--- a/theories/gen_tuple.ml
+++ b/theories/gen_tuple.ml
@@ -37,7 +37,7 @@ let pp_term_args fmt l =
 
 let pp_inductive fmt n =
   fprintf fmt
-    "@[<v>Inductive tupl%d (%a : Type) :=@ @[<v 2>| mktupl%d %a@ : tupl%d \
+    "@[<v>Inductive tuple%d (%a : Type) :=@ @[<v 2>| mktuple%d %a@ : tuple%d \
      %a.@]@]"
     n pp_poly_args (1 -- n) n
     (pp_print_list
@@ -46,7 +46,7 @@ let pp_inductive fmt n =
     (1 -- n) n pp_poly_args (1 -- n)
 
 let pp_arguments fmt n =
-  fprintf fmt "@[<v>Arguments mktupl%d [%a] (%a).@]" n pp_poly_args (1 -- n)
+  fprintf fmt "@[<v>Arguments mktuple%d [%a] (%a).@]" n pp_poly_args (1 -- n)
     pp_term_args (1 -- n)
 
 let pp_prod_arg fmt n =
@@ -58,13 +58,13 @@ let pp_prod_arg fmt n =
 
 let pp_instance fmt n =
   fprintf fmt
-    "@[<v 2>Instance tupl%d_of_prod {%a}@ : _OfProd (%a) (tupl%d %a) := @ %a.@]"
+    "@[<v 2>Instance tuple%d_of_prod {%a}@ : _OfProd (%a) (tuple%d %a) := @ %a.@]"
     n pp_poly_args (1 -- n)
     (pp_print_list ~pp_sep:(fun fmt _ -> pp_print_string fmt " * ") pp_poly_arg)
     (1 -- n) n pp_poly_args (1 -- n)
     (fun fmt _ ->
       fprintf fmt
-        "@[<v>{ of_prod := fun '%a => mktupl%d %a@ ; to_prod := fun '(mktupl%d \
+        "@[<v>{ of_prod := fun '%a => mktuple%d %a@ ; to_prod := fun '(mktuple%d \
          %a) => %a }@]"
         pp_prod_arg n n pp_term_args (1 -- n) n pp_term_args (1 -- n)
         pp_prod_arg n)
@@ -77,7 +77,7 @@ let pp_extraction fmt n =
     (pp_print_list
        ~pp_sep:(fun fmt _ -> fprintf fmt "@ @ ")
        (fun fmt n ->
-         fprintf fmt "Extract Inductive tupl%d => \"Shim.tupl%d\" [ \"\" ]." n n))
+         fprintf fmt "Extract Inductive tuple%d => \"Shim.tuple%d\" [ \"\" ]." n n))
     (3 -- n)
 
 let _ =


### PR DESCRIPTION
With all the respect I have for https://github.com/coq-community/coqffi/commit/a21b10db55a5ae47ffc14f3826693bfd6a2bfa6d. `tuplN` is not good