### PR TITLE
Try to fix installation script for OCaml 14.4 on Mac OSX

### DIFF
--- a/src-prepare.sh
+++ b/src-prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-ocaml_version="$(ocamlc --version|sed - -e 's/\(4\.[0-9][0-9]\)\..*/\1/')"
-coq_version="$(coqc --version|head -n1|sed - -e 's/.*\(8\.[0-9][0-9]\).*/\1/')"
+ocaml_version="$(ocamlc --version|sed -e 's/\(4\.[0-9][0-9]\)\..*/\1/')"
+coq_version="$(coqc --version|head -n1|sed -e 's/.*\(8\.[0-9][0-9]\).*/\1/')"
 
 case "${ocaml_version}" in
     4.14) true ;;


### PR DESCRIPTION
Hi there 👋 

I tried to install coqffi (on Mac OSX) using the instructions in README.md but the command `opam install .` 
failed with the following message :
```
[ERROR] The compilation of coq-coqffi.dev failed at "./src-prepare.sh".

#=== ERROR while compiling coq-coqffi.dev =====================================#
# context     2.1.3 | macos/arm64 | ocaml.4.14.0 | pinned(git+file:///Users/arthur/Documents/github/coqffi#main#25448de5)
# path        ~/.opam/default/.opam-switch/build/coq-coqffi.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build ./src-prepare.sh
# exit-code   1
# env-file    ~/.opam/log/coq-coqffi-17538-14d9c1.env
# output-file ~/.opam/log/coq-coqffi-17538-14d9c1.out
### output ###
# sed: 1: "-": invalid command code -
# sed: 1: "-": invalid command code -
# unsupported OCaml version
```

After inspecting the script `./src-prepare.sh` I realized the problem comes from the command `sed - -e ...`
I could not find any documentation on the commande code `-` for sed but I realized that simply removing it solves the problem (and the CI still passes)...

If someone knows what is the problem I am very curious 😄 !
